### PR TITLE
Update junit_reporter.rb

### DIFF
--- a/lib/minitest/reporters/junit_reporter.rb
+++ b/lib/minitest/reporters/junit_reporter.rb
@@ -33,7 +33,7 @@ module Minitest
         if @single_file
           xml = Builder::XmlMarkup.new(:indent => 2)
           xml.instruct!
-          xml.test_suites do
+          xml.testsuites do
             suites.each do |suite, tests|
               parse_xml_for(xml, suite, tests)
             end
@@ -43,7 +43,7 @@ module Minitest
           suites.each do |suite, tests|
             xml = Builder::XmlMarkup.new(:indent => 2)
             xml.instruct!
-            xml.test_suites do
+            xml.testsuites do
               parse_xml_for(xml, suite, tests)
             end
             File.open(filename_for(suite), "w") { |file| file << xml.target! }


### PR DESCRIPTION
Hi,

To me the junit file should start with <testsuites> and not <test_suites> otherwise it is not compliant with Junit XSD. 

Do you confirm ?
Thanks